### PR TITLE
Added required annotation for new config system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Added required annotation for new config system.
+
 ## [0.6.0] - 2021-09-10
 
 ### Changed

--- a/helm/azure-ad-pod-identity-app/Chart.yaml
+++ b/helm/azure-ad-pod-identity-app/Chart.yaml
@@ -9,3 +9,6 @@ sources:
 icon: https://s.giantswarm.io/app-icons/1/png/azure-ad-pod-identity-app-light.png
 restrictions:
   compatibleProviders: ["azure"]
+annotations:
+  application.giantswarm.io/team: "celestial"
+  config.giantswarm.io/version: 1.x.x


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19091

@QuentinBisson @T-Kukawka This is an app that we offer in our catalogs, but we also use it in our management clusters. Is it fine to use these annotations for public apps?