### PR TITLE
Reduce CPU request for nmi container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce NMI CPU request from 100m to 50m.
+
 ## [0.8.0] - 2022-02-17
 
 ### Added

--- a/helm/azure-ad-pod-identity-app/values.yaml
+++ b/helm/azure-ad-pod-identity-app/values.yaml
@@ -155,7 +155,7 @@ nmi:
       cpu: 200m
       memory: 512Mi
     requests:
-      cpu: 100m
+      cpu: 50m
       memory: 256Mi
 
   podAnnotations: {}


### PR DESCRIPTION
NMI container CPU request is too high

```
$ k top pod -n giantswarm -l app.kubernetes.io/name=azure-ad-pod-identity-app
NAME                                  CPU(cores)   MEMORY(bytes)   
azure-ad-pod-identity-app-nmi-69p7v   1m           37Mi            
azure-ad-pod-identity-app-nmi-k5hbg   1m           37Mi            
azure-ad-pod-identity-app-nmi-klsbj   1m           41Mi            
azure-ad-pod-identity-app-nmi-lqvjp   1m           42Mi            
azure-ad-pod-identity-app-nmi-mtd6q   1m           41Mi            
azure-ad-pod-identity-app-nmi-thw2n   1m           40Mi
```

Reducing from 100m to 50m make scheduling easier.