### PR TITLE
Update: CRD apiextensions version

### DIFF
--- a/helm/azure-ad-pod-identity-app/crds/crd.yaml
+++ b/helm/azure-ad-pod-identity-app/crds/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: azureassignedidentities.aadpodidentity.k8s.io
@@ -16,7 +16,7 @@ spec:
     plural: azureassignedidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: azureidentitybindings.aadpodidentity.k8s.io
@@ -34,7 +34,7 @@ spec:
     plural: azureidentitybindings
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: azureidentities.aadpodidentity.k8s.io
@@ -53,7 +53,7 @@ spec:
     plural: azureidentities
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: azurepodidentityexceptions.aadpodidentity.k8s.io


### PR DESCRIPTION
This PR tries to fix the error that occurs when trying to install in a cluster thats v1.22 and greater. It results in  no matches for kind "`CustomResourceDefinition`" in version "`apiextensions.k8s.io/v1beta1`”’ This is because the beta CustomResourceDefinition API (apiextensions.k8s.io/v1beta1) was removed in 1.22. See [here](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#api-changes)