### PR TITLE
Fix RBAC api version in helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update `rbac.authorization.k8s.io/v1beta1` to `rbac.authorization.k8s.io/v1` for RBAC resources in helm chart.
+
 ## [0.10.2] - 2022-06-20
 
 ### Changed

--- a/helm/azure-ad-pod-identity-app/.kube-linter.yaml
+++ b/helm/azure-ad-pod-identity-app/.kube-linter.yaml
@@ -14,3 +14,4 @@ checks:
     - "run-as-non-root"
     - "host-network"
     - "drop-net-raw-capability"
+    - "access-to-secrets"

--- a/helm/azure-ad-pod-identity-app/templates/mic-clusterrolebinding.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/mic-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.rbac.enabled (eq .Values.operationMode "standard") }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}

--- a/helm/azure-ad-pod-identity-app/templates/nmi-clusterrolebinding.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/nmi-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "aad-pod-identity.nmi.fullname" . }}

--- a/helm/azure-ad-pod-identity-app/templates/np.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/np.yaml
@@ -16,7 +16,7 @@ spec:
       protocol: TCP
   podSelector:
     matchLabels:
-      {{- include "aad-pod-identity.selectors" . | nindent 4 }}
+      {{- include "aad-pod-identity.selectors" . | nindent 6 }}
   policyTypes:
   - Egress
   - Ingress


### PR DESCRIPTION
Newer cluster have the version removed