### PR TITLE
Bump upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Bump manifests and image to upstream version 1.8.10.
 - Bind NMI pods to all interfaces.
 - Use correct apiVersion for PDB based on k8s version.
+- Avoid creating any MIC related resource if operatingMode is not `standard`.
 
 ## [0.10.4] - 2022-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Bump manifests and image to upstream version 1.8.10.
+- Bind NMI pods to all interfaces.
+- Use correct apiVersion for PDB based on k8s version.
+
 ## [0.10.4] - 2022-07-06
 
 - Update CRD resources in helm chart.

--- a/helm/azure-ad-pod-identity-app/templates/mic-hpa.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/mic-hpa.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.operationMode "standard" }}
 {{ if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" }}
 {{- if .Values.mic.autoscaling.enabled }}
 apiVersion: autoscaling/v2beta1
@@ -28,5 +29,6 @@ spec:
         name: memory
         targetAverageUtilization: {{ . }}
     {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/azure-ad-pod-identity-app/templates/mic-pod-disruption-budget.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/mic-pod-disruption-budget.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.mic.podDisruptionBudget }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}-pdb

--- a/helm/azure-ad-pod-identity-app/templates/mic-pod-disruption-budget.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/mic-pod-disruption-budget.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.operationMode "standard" }}
 {{- if .Values.mic.podDisruptionBudget }}
 {{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
@@ -14,4 +15,5 @@ spec:
     matchLabels:
       app.kubernetes.io/component: mic
       {{- include "aad-pod-identity.selectors" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/helm/azure-ad-pod-identity-app/templates/nmi-daemonset.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/nmi-daemonset.yaml
@@ -37,7 +37,7 @@ spec:
       - name: iptableslock
         hostPath:
           path: /run/xtables.lock
-          type: FileOrCreate 
+          type: FileOrCreate
       {{- if semverCompare ">= 1.7.0-0" .Values.nmi.image.tag }}
       - name: kubelet-config
         hostPath:
@@ -102,6 +102,9 @@ spec:
           {{- end }}
           {{- if .Values.customUserAgent }}
           - --custom-user-agent={{ .Values.customUserAgent }}
+          {{- end }}
+          {{- if .Values.nmi.listenAddress }}
+          - --nmi-listen-address={{ .Values.nmi.listenAddress }}
           {{- end }}
         env:
         {{- if semverCompare "<= 1.6.1-0" .Values.nmi.image.tag }}

--- a/helm/azure-ad-pod-identity-app/templates/nmi-vpa.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/nmi-vpa.yaml
@@ -15,7 +15,7 @@ spec:
       mode: Auto
   targetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: DaemonSet
     name: {{ template "aad-pod-identity.nmi.fullname" . }}
   updatePolicy:
     updateMode: Auto

--- a/helm/azure-ad-pod-identity-app/values.yaml
+++ b/helm/azure-ad-pod-identity-app/values.yaml
@@ -44,7 +44,7 @@ operationMode: "standard"
 mic:
   image:
     name: giantswarm/mic
-    tag: v1.8.3
+    tag: v1.8.10
 
   priorityClassName: ""
 
@@ -147,7 +147,9 @@ mic:
 nmi:
   image:
     name: giantswarm/nmi
-    tag: v1.8.3
+    tag: v1.8.10
+
+  listenAddress: "0.0.0.0"
 
   priorityClassName: "system-node-critical"
 


### PR DESCRIPTION
- Bump manifests and image to upstream version 1.8.10.
- Bind NMI pods to all interfaces.
- Use correct apiVersion for PDB based on k8s version.