### PR TITLE
Disable `metadataHeaderRequired` by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable `metadataHeaderRequired` by default.
+
 ## [0.11.0] - 2022-07-08
 
 ### Changed

--- a/helm/azure-ad-pod-identity-app/values.yaml
+++ b/helm/azure-ad-pod-identity-app/values.yaml
@@ -208,7 +208,7 @@ nmi:
   blockInstanceMetadata: ""
 
   # https://github.com/Azure/aad-pod-identity/blob/master/docs/readmes/README.featureflags.md#metadata-header-required-flag (default is false)
-  metadataHeaderRequired: ""
+  metadataHeaderRequired: false
 
   # enable running aad-pod-identity on clusters with kubenet
   # default is false


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1136

by default, aad-pod-identity wants a `metadata: true` header to be set for requests to azure IMDS, or the call is rejected.
cluster-autoscaler does not provide such header, and thus its calls to IMDS are rejected, making it fail.

With this change we disable the behaviour by default.