### PR TITLE
Allow users to specify AzurePodIdentityException names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Allow users to specify AzurePodIdentityException names.
+  
 ## [0.15.1] - 2024-01-22
 
 ### Added

--- a/helm/azure-ad-pod-identity-app/templates/exception.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/exception.yaml
@@ -4,7 +4,7 @@
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzurePodIdentityException
 metadata:
-  name: ad-id-exc-{{ . }}
+  name: {{ if $exception.name }}{{ $exception.name }}{{ else }}ad-id-exc-{{ . }}{{ end }}
   namespace: {{ . }}
 spec:
   podLabels:

--- a/helm/azure-ad-pod-identity-app/values.yaml
+++ b/helm/azure-ad-pod-identity-app/values.yaml
@@ -258,7 +258,8 @@ customUserAgent: ""
 
 # AzurePodIdentityException CRs to be created to make azure-ad-pod-identity ignore some pods.
 exceptions: []
-# - namespaces:
+# - name: exception-name
+#   namespaces:
 #   - kube-system
 #   podLabels:
 #     ad-pod-identity: skip


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29803

When we want to create multiple exceptions in the same namespace for different pod labels, CR names conflict now and we can have only one of them.

This PR allows users to specify rule names in a backward-compatible way.

This is our default config for MC now.
```
exceptions:
- namespaces: ["kube-system"]
  podLabels:
    app: cluster-autoscaler
```

It will be 
```
exceptions:
- name: cluster-autoscaler 
  namespaces: ["kube-system"]
  podLabels:
    app: cluster-autoscaler
- name: cert-manager
  namespaces: ["kube-system"]
  podLabels:
    app.kubernetes.io/component: controller
    app.kubernetes.io/name: cert-manager-app
- name: external-dns
  namespaces: ["kube-system"]
  podLabels:
    app.kubernetes.io/name: external-dns
```