### PR TITLE
add-toleration-for-unitialized-nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add toleration for `node.cluster.x-k8s.io/uninitialized` and `node-role.kubernetes.io/control-plane` taints.
+- Add node affinity to prefer schedule on `control-plane` nodes.
+
 ## [0.15.3] - 2024-04-02
 
 ### Changed

--- a/helm/azure-ad-pod-identity-app/values.yaml
+++ b/helm/azure-ad-pod-identity-app/values.yaml
@@ -76,9 +76,21 @@ mic:
   nodeSelector:
     kubernetes.io/os: linux
 
-  tolerations: []
+  tolerations: 
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+  - effect: NoSchedule
+    key: "node.cluster.x-k8s.io/uninitialized"
+    operator: "Exists"
 
-  affinity: {}
+  affinity: 
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+        weight: 10
 
   # Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
   # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/


### PR DESCRIPTION
# Added

- Add toleration for `node.cluster.x-k8s.io/uninitialized` and `node-role.kubernetes.io/control-plane` taints.
- Add node affinity to prefer schedule on `control-plane` nodes.

