### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Bump `apiVersion` for Kyverno PolicyExceptions from `v2alpha1` to `v2beta1`.
 
+### Fixed
+
+- Fixed liveness probe configuration by explicitly exposing probe ports in NMI daemonset and MIC deployment.
+
 ## [0.15.4] - 2024-07-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `apiVersion` for Kyverno PolicyExceptions from `v2alpha1` to `v2beta1`.
+
 ## [0.15.4] - 2024-07-29
 
 ### Changed
@@ -29,7 +33,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Allow users to specify AzurePodIdentityException names.
-  
+
 ## [0.15.1] - 2024-01-22
 
 ### Added

--- a/helm/azure-ad-pod-identity-app/templates/mic-deployment.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/mic-deployment.yaml
@@ -175,6 +175,9 @@ spec:
           - containerPort: {{ .Values.mic.prometheusPort }}
             name: metrics
             protocol: TCP
+          - containerPort: {{ .Values.mic.probePort | default 8080 }}
+            name: probe
+            protocol: TCP
         {{- end }}
         {{- if not .Values.adminsecret }}
         volumeMounts:

--- a/helm/azure-ad-pod-identity-app/templates/nmi-daemonset.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/nmi-daemonset.yaml
@@ -133,6 +133,13 @@ spec:
             - DAC_READ_SEARCH
             - NET_ADMIN
             - NET_RAW
+        ports:
+          - containerPort: {{ .Values.nmi.prometheusPort }}
+            name: metrics
+            protocol: TCP
+          - containerPort: {{ .Values.nmi.probePort | default 8080 }}
+            name: probe
+            protocol: TCP
         volumeMounts:
         - name: iptableslock
           mountPath: /run/xtables.lock

--- a/helm/azure-ad-pod-identity-app/templates/nmi-pss-exceptions.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/nmi-pss-exceptions.yaml
@@ -1,4 +1,4 @@
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ template "aad-pod-identity.nmi.fullname" . }}-exceptions


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.