### PR TITLE
Bump autoscaling to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `autoscaling` version to `v2` for `HorizontalPodAutoscaler`.
+
 ### Added
 
 - Add toleration for `node.cluster.x-k8s.io/uninitialized` and `node-role.kubernetes.io/control-plane` taints.

--- a/helm/azure-ad-pod-identity-app/templates/mic-hpa.yaml
+++ b/helm/azure-ad-pod-identity-app/templates/mic-hpa.yaml
@@ -1,7 +1,7 @@
 {{- if eq .Values.operationMode "standard" }}
-{{ if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" }}
+{{ if .Capabilities.APIVersions.Has "autoscaling/v2" }}
 {{- if .Values.mic.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "aad-pod-identity.mic.fullname" . }}
@@ -21,13 +21,17 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ . }}
+        target:
+          averageUtilization: {{ . }}
+          type: Utilization
     {{- end }}
     {{- with .Values.mic.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ . }}
+        target:
+          averageUtilization: {{ . }}
+          type: Utilization
     {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/azure-ad-pod-identity-app/values.yaml
+++ b/helm/azure-ad-pod-identity-app/values.yaml
@@ -56,7 +56,7 @@ mic:
   # Contains optional horizontal-pod-autoscaler (hpa) settings
   autoscaling:
     enabled: true
-    minReplicas: 2
+    minReplicas: 3
     maxReplicas: 10
     targetCPUUtilizationPercentage: 50
     targetMemoryUtilizationPercentage: 80


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/30866

Notes:
- We deploy this app to MCs in "managed" mode so we don't render HPA in MCs. 
- I tested this PR by running "helm template" with standard mode and then applying the HPA in our test MC manually.
- HPA doesn't exist in the upstream chart. It is something we added manually.
- We will remove this app completely while bumping CAPZ to the latest.
- Our minimum k8s version is 1.25.
- k8s deprecation notes
```
The autoscaling/v2beta2 API version of HorizontalPodAutoscaler is no longer served as of v1.26.
- Migrate manifests and API clients to use the autoscaling/v2 API version, available since v1.23.
- All existing persisted objects are accessible via the new API
- Notable changes: targetAverageUtilization is replaced with target.averageUtilization and target.type: Utilization. See [Autoscaling on multiple metrics and custom metrics](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
```
